### PR TITLE
Use Youtube’s “nocookie” domain by default

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,9 @@
 module.exports = function(eleventyConfig, options) {
+  const defaults = {
+    noCookie: true
+  };
+  const pluginConfig = Object.assign(defaults, options);
+
   eleventyConfig.addTransform("embedYouTube", async (content, outputPath) => {
     if (!outputPath.endsWith(".html")) {
       return content;
@@ -14,26 +19,28 @@ module.exports = function(eleventyConfig, options) {
     });
     return content;
   });
+  function contentContainsYouTubeUrls(str) {
+    const youTubeUrlPattern = /<p>(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=)?([A-Za-z0-9-_]{11})(.*)<\/p>/g;
+    return str.match(youTubeUrlPattern);
+  }
+
+  function extractVideoId(str) {
+    // need to use exec to get named regex groups
+    const thisPattern = /<p>(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=)?(?<videoId>[A-Za-z0-9-_]{11})(.*)<\/p>/;
+    return thisPattern.exec(str).groups.videoId;
+  }
+  pluginConfig;
+  function buildEmbedCodeString(id) {
+    let out =
+      '<div style="position:relative;width: 100%;padding-top: 56.25%;">';
+    out +=
+      '<iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" ';
+    out += 'width="100%" height="100%" frameborder="0" allowfullscreen ';
+    out += 'src="https://www.';
+    out += pluginConfig.noCookie ? "youtube-nocookie" : "youtube";
+    out += ".com/embed/";
+    out += id;
+    out += '"></iframe></div>';
+    return out;
+  }
 };
-
-function contentContainsYouTubeUrls(str) {
-  const youTubeUrlPattern = /<p>(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=)?([A-Za-z0-9-_]{11})(.*)<\/p>/g;
-  return str.match(youTubeUrlPattern);
-}
-
-function extractVideoId(str) {
-  // need to use exec to get named regex groups
-  const thisPattern = /<p>(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=)?(?<videoId>[A-Za-z0-9-_]{11})(.*)<\/p>/;
-  return thisPattern.exec(str).groups.videoId;
-}
-
-function buildEmbedCodeString(id) {
-  let out = '<div style="position:relative;width: 100%;padding-top: 56.25%;">';
-  out +=
-    '<iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" ';
-  out += 'width="100%" height="100%" frameborder="0" allowfullscreen ';
-  out += 'src="https://www.youtube.com/embed/';
-  out += id;
-  out += '"></iframe></div>';
-  return out;
-}

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -19,6 +19,8 @@ module.exports = function(eleventyConfig, options) {
     });
     return content;
   });
+
+  // Helper functions
   function contentContainsYouTubeUrls(str) {
     const youTubeUrlPattern = /<p>(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=)?([A-Za-z0-9-_]{11})(.*)<\/p>/g;
     return str.match(youTubeUrlPattern);
@@ -29,7 +31,7 @@ module.exports = function(eleventyConfig, options) {
     const thisPattern = /<p>(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=)?(?<videoId>[A-Za-z0-9-_]{11})(.*)<\/p>/;
     return thisPattern.exec(str).groups.videoId;
   }
-  pluginConfig;
+
   function buildEmbedCodeString(id) {
     let out =
       '<div style="position:relative;width: 100%;padding-top: 56.25%;">';


### PR DESCRIPTION
Close #3 

Adds a configurable option to use the `youtube-nocookie` domain by default.

Also moves the helper functions inside the `module.export` function so they’re actually in scope to use the plugin config object, which...duh