### PR TITLE
Allow surrounding whitespace

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -22,13 +22,13 @@ module.exports = function(eleventyConfig, options) {
 
   // Helper functions
   function contentContainsYouTubeUrls(str) {
-    const youTubeUrlPattern = /<p>(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=)?([A-Za-z0-9-_]{11})(.*)<\/p>/g;
+    const youTubeUrlPattern = /<p>(\s*)?(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=|embed\/)?([A-Za-z0-9-_]{11})(\S*)(\s*)?<\/p>/g;
     return str.match(youTubeUrlPattern);
   }
 
   function extractVideoId(str) {
     // need to use exec to get named regex groups
-    const thisPattern = /<p>(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=)?(?<videoId>[A-Za-z0-9-_]{11})(.*)<\/p>/;
+    const thisPattern = /<p>(\s*)?(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=|embed\/)?(?<videoId>[A-Za-z0-9-_]{11})(\S*)(\s*)?<\/p>/;
     return thisPattern.exec(str).groups.videoId;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-youtube-embed",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An Eleventy plugin to automatically embed YouTube videos, using just their URLs.",
   "keywords": [
     "11ty",


### PR DESCRIPTION
Close #8 

Two regex issues addressed with this PR:

### Whitespace

The original regex pattern didn’t allow for any whitespace between the surrounding `<p>` tags and the YouTube URL contained inside it, which was brittle and unforgiving. This PR updates the pattern to allow for arbitrary whitespace inside the element, on each side of the URL.

Any other text contained inside the paragraph, however, will cause the embed to fail, as intended.

### Enable support for `embed` URLs

The example included in the original bug report didn’t just include whitespace; it also used YouTube’s `/embed/` URL — the one used to embed, not the ones seen by most casual browsers. The regex will now also recognize embed URLs, such as:

```
https://www.youtube.com/embed/1dgLEDdFddk
```
The updated pattern can be seen in action here, with examples: https://regex101.com/r/wSkwtj/12
