### PR TITLE
Add configurable class and ID on embed wrapper

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,7 @@
 module.exports = function(eleventyConfig, options) {
   const defaults = {
-    noCookie: true
+    noCookie: true,
+    embedClass: 'eleventy-plugin-youtube-embed',
   };
   const pluginConfig = Object.assign(defaults, options);
 
@@ -34,7 +35,9 @@ module.exports = function(eleventyConfig, options) {
 
   function buildEmbedCodeString(id) {
     let out =
-      '<div style="position:relative;width: 100%;padding-top: 56.25%;">';
+      '<div id="' + id + '" ';
+    out += 'class="' + pluginConfig.embedClass + '"';
+    out += 'style="position:relative;width:100%;padding-top: 56.25%;">';
     out +=
       '<iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" ';
     out += 'width="100%" height="100%" frameborder="0" allowfullscreen ';


### PR DESCRIPTION
Close #1 

This PR adds the following to the wrapper `div` on the embed:

- A unique `id`, based on the id of the YouTube video
- A class for all embeds, which can be configured when activating the plugin

```javascript
eleventyConfig.addPlugin(embedYoutube, {
  embedClass: 'whatever string you want'
  // default: 'eleventy-plugin-youtube-embed'
});
```


