### PR TITLE
Enable configurable allow attribute, allowfullscreen, and autoplay 

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,6 +2,9 @@ module.exports = function(eleventyConfig, options) {
   const defaults = {
     noCookie: true,
     embedClass: 'eleventy-plugin-youtube-embed',
+    allowAttrs: 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
+    allowFullscreen: true,
+    autoplay: false
   };
   const pluginConfig = Object.assign(defaults, options);
 
@@ -34,18 +37,31 @@ module.exports = function(eleventyConfig, options) {
   }
 
   function buildEmbedCodeString(id) {
+    // Build the string, using config data as we go
+    // unique ID based on youtube video id
     let out =
       '<div id="' + id + '" ';
+    // global class name for all embeds, use this for styling
     out += 'class="' + pluginConfig.embedClass + '"';
+    // intrinsic aspect ratio; currently hard-coded to 16:9
+    // TODO: make configurable somehow
     out += 'style="position:relative;width:100%;padding-top: 56.25%;">';
     out +=
       '<iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" ';
-    out += 'width="100%" height="100%" frameborder="0" allowfullscreen ';
+    out += 'width="100%" height="100%" frameborder="0" ';
     out += 'src="https://www.';
+    // default to nocookie domain
     out += pluginConfig.noCookie ? "youtube-nocookie" : "youtube";
-    out += ".com/embed/";
+    out += '.com/embed/';
     out += id;
-    out += '"></iframe></div>';
+    // autoplay is _technically_ possible, but be cool, don't do this
+    out += pluginConfig.autoplay ? '?autoplay=1' : '';
+    out += '" ';
+    // configurable allow attributes
+    out += 'allow="' + pluginConfig.allowAttrs + '"';
+    // configurable fullscreen capability
+    out += pluginConfig.allowFullscreen ? ' allowfullscreen' : '';
+    out += '></iframe></div>';
     return out;
   }
 };

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,7 +4,7 @@ module.exports = function(eleventyConfig, options) {
     embedClass: 'eleventy-plugin-youtube-embed',
     allowAttrs: 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
     allowFullscreen: true,
-    autoplay: false
+    allowAutoplay: false
   };
   const pluginConfig = Object.assign(defaults, options);
 
@@ -55,7 +55,7 @@ module.exports = function(eleventyConfig, options) {
     out += '.com/embed/';
     out += id;
     // autoplay is _technically_ possible, but be cool, don't do this
-    out += pluginConfig.autoplay ? '?autoplay=1' : '';
+    out += pluginConfig.allowAutoplay ? '?autoplay=1' : '';
     out += '" ';
     // configurable allow attributes
     out += 'allow="' + pluginConfig.allowAttrs + '"';


### PR DESCRIPTION
Close #7 

I thought about how to implement the `allow` attribute on the iframe element, and I think the best approach is to duplicate the existing behavior of the native YouTube embed code. This PR does the following:

- Adds a configurable default value for the `allow`value
- Adds a configurable setting to control the `allowfullscreen` boolean attribute (default: `true`, which matches the default native YouTube embed code)
- Adds a configurable setting to allow autoplay (default: `false`) 