### PR TITLE
Switch regex method from named capture groups to destructuring

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -31,9 +31,10 @@ module.exports = function(eleventyConfig, options) {
   }
 
   function extractVideoId(str) {
-    // need to use exec to get named regex groups
-    const thisPattern = /<p>(\s*)(<a(.*)>)?(\s*)(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=|embed\/)?(?<videoId>[A-Za-z0-9-_]{11})(\S*)(\s*)(<\/a>)?(\s*)<\/p>/;
-    return thisPattern.exec(str).groups.videoId;
+    // CHANGE @1.3.0: Remove named capture group (Node ^10). Instead use destructuring (Node ^6).
+    const thisPattern = /<p>(?:\s*)(?:<a(?:.*)>)?(?:\s*)(?:https?:\/\/)?(?:w{3}\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/)?([A-Za-z0-9-_]{11})(?:\S*)(?:\s*)(?:<\/a>)?(?:\s*)<\/p>/;
+    let [ match, out ] = thisPattern.exec(str);
+    return out;
   }
 
   function buildEmbedCodeString(id) {


### PR DESCRIPTION
Close #14 

Regular Expression named capture groups are only available in Node 10 and up, while destructuring is supported back to 6.0.0. Switching the pattern-matching method will broaden support for more build environments and, hopefully, reduce errors.

This pattern also reduces the margin for error by making most groups non-capturing, and only returning the youtube video ID.

Going to do some additional testing before merging this.