### PR TITLE
Refactor as modules

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,68 +1,23 @@
-module.exports = function(eleventyConfig, options) {
-  const defaults = {
-    noCookie: true,
-    embedClass: 'eleventy-plugin-youtube-embed',
-    allowAttrs: 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
-    allowFullscreen: true,
-    allowAutoplay: false
-  };
-  const pluginConfig = Object.assign(defaults, options);
+const patternPresent = require('./lib/spotPattern.js');
+const extractVideoId = require('./lib/extractMatches.js');
+const buildEmbedCodeString = require('./lib/buildEmbed.js');
+const pluginDefaults = require('./lib/pluginDefaults.js');
 
+module.exports = function(eleventyConfig, options) {
+  const pluginConfig = Object.assign(pluginDefaults, options);
   eleventyConfig.addTransform("embedYouTube", async (content, outputPath) => {
     if (!outputPath.endsWith(".html")) {
       return content;
     }
-    let matches = contentContainsYouTubeUrls(content);
+    let matches = patternPresent(content);
     if (!matches) {
       return content;
     }
-    matches.forEach(function(youTubeStringToReplace) {
-      let videoId = extractVideoId(youTubeStringToReplace);
-      let youTubeEmbedCode = buildEmbedCodeString(videoId);
-      content = content.replace(youTubeStringToReplace, youTubeEmbedCode);
+    matches.forEach(function(stringToReplace) {
+      let videoId = extractVideoId(stringToReplace);
+      let embedCode = buildEmbedCodeString(videoId, pluginConfig);
+      content = content.replace(stringToReplace, embedCode);
     });
     return content;
   });
-
-  // Helper functions
-  function contentContainsYouTubeUrls(str) {
-    const youTubeUrlPattern = /<p>(\s*)(<a(.*)>)?(\s*)(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=|embed\/)?([A-Za-z0-9-_]{11})(\S*)(\s*)(<\/a>)?(\s*)<\/p>/g;
-    return str.match(youTubeUrlPattern);
-  }
-
-  function extractVideoId(str) {
-    // CHANGE @1.3.0: Remove named capture group (Node ^10). Instead use destructuring (Node ^6).
-    const thisPattern = /<p>(?:\s*)(?:<a(?:.*)>)?(?:\s*)(?:https?:\/\/)?(?:w{3}\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/)?([A-Za-z0-9-_]{11})(?:\S*)(?:\s*)(?:<\/a>)?(?:\s*)<\/p>/;
-    let [ match, out ] = thisPattern.exec(str);
-    return out;
-  }
-
-  function buildEmbedCodeString(id) {
-    // Build the string, using config data as we go
-    // unique ID based on youtube video id
-    let out =
-      '<div id="' + id + '" ';
-    // global class name for all embeds, use this for styling
-    out += 'class="' + pluginConfig.embedClass + '"';
-    // intrinsic aspect ratio; currently hard-coded to 16:9
-    // TODO: make configurable somehow
-    out += 'style="position:relative;width:100%;padding-top: 56.25%;">';
-    out +=
-      '<iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" ';
-    out += 'width="100%" height="100%" frameborder="0" ';
-    out += 'src="https://www.';
-    // default to nocookie domain
-    out += pluginConfig.noCookie ? "youtube-nocookie" : "youtube";
-    out += '.com/embed/';
-    out += id;
-    // autoplay is _technically_ possible, but be cool, don't do this
-    out += pluginConfig.allowAutoplay ? '?autoplay=1' : '';
-    out += '" ';
-    // configurable allow attributes
-    out += 'allow="' + pluginConfig.allowAttrs + '"';
-    // configurable fullscreen capability
-    out += pluginConfig.allowFullscreen ? ' allowfullscreen' : '';
-    out += '></iframe></div>';
-    return out;
-  }
 };

--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -1,0 +1,28 @@
+module.exports = function(id, options) {
+  // Build the string, using config data as we go
+  // unique ID based on youtube video id
+  let out =
+    '<div id="' + id + '" ';
+  // global class name for all embeds, use this for styling
+  out += 'class="' + options.embedClass + '"';
+  // intrinsic aspect ratio; currently hard-coded to 16:9
+  // TODO: make configurable somehow
+  out += 'style="position:relative;width:100%;padding-top: 56.25%;">';
+  out +=
+    '<iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" ';
+  out += 'width="100%" height="100%" frameborder="0" ';
+  out += 'src="https://www.';
+  // default to nocookie domain
+  out += options.noCookie ? "youtube-nocookie" : "youtube";
+  out += '.com/embed/';
+  out += id;
+  // autoplay is _technically_ possible, but be cool, don't do this
+  out += options.allowAutoplay ? '?autoplay=1' : '';
+  out += '" ';
+  // configurable allow attributes
+  out += 'allow="' + options.allowAttrs + '"';
+  // configurable fullscreen capability
+  out += options.allowFullscreen ? ' allowfullscreen' : '';
+  out += '></iframe></div>';
+  return out;
+}

--- a/lib/extractMatches.js
+++ b/lib/extractMatches.js
@@ -1,0 +1,7 @@
+const thisPattern = /<p>(?:\s*)(?:<a(?:.*)>)?(?:\s*)(?:https?:\/\/)?(?:w{3}\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/)?([A-Za-z0-9-_]{11})(?:\S*)(?:\s*)(?:<\/a>)?(?:\s*)<\/p>/;
+
+module.exports = function(str) {
+  // CHANGE @1.3.0: Remove named capture group (Node ^10). Instead use destructuring (Node ^6).
+  let [ match, out ] = thisPattern.exec(str);
+  return out;
+}

--- a/lib/pluginDefaults.js
+++ b/lib/pluginDefaults.js
@@ -1,0 +1,7 @@
+module.exports = {
+  noCookie: true,
+  embedClass: 'eleventy-plugin-youtube-embed',
+  allowAttrs: 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
+  allowFullscreen: true,
+  allowAutoplay: false
+};

--- a/lib/spotPattern.js
+++ b/lib/spotPattern.js
@@ -1,0 +1,5 @@
+const pattern = /<p>(\s*)(<a(.*)>)?(\s*)(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=|embed\/)?([A-Za-z0-9-_]{11})(\S*)(\s*)(<\/a>)?(\s*)<\/p>/g;
+
+module.exports = function(str) {
+  return str.match(pattern);
+}


### PR DESCRIPTION
This PR refactors the plugin as a series of modules. The goal is to accommodate testing; there was no good way in the previous architecture to test any of the helper functions, which were written as private methods.

This doesn’t change the functionality of the plugin within an Eleventy instance. It's just a refactor under the hood.