### PR TITLE
Fix for when outputpath is not available

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,21 +3,22 @@ const extractVideoId = require('./lib/extractMatches.js');
 const buildEmbedCodeString = require('./lib/buildEmbed.js');
 const pluginDefaults = require('./lib/pluginDefaults.js');
 
-module.exports = function(eleventyConfig, options) {
+module.exports = function (eleventyConfig, options) {
   const pluginConfig = Object.assign(pluginDefaults, options);
   eleventyConfig.addTransform("embedYouTube", async (content, outputPath) => {
-    if (!outputPath.endsWith(".html")) {
+    if (outputPath && outputPath.endsWith(".html")) {
+      let matches = patternPresent(content);
+      if (!matches) {
+        return content;
+      }
+      matches.forEach(function (stringToReplace) {
+        let videoId = extractVideoId(stringToReplace);
+        let embedCode = buildEmbedCodeString(videoId, pluginConfig);
+        content = content.replace(stringToReplace, embedCode);
+      });
       return content;
     }
-    let matches = patternPresent(content);
-    if (!matches) {
-      return content;
-    }
-    matches.forEach(function(stringToReplace) {
-      let videoId = extractVideoId(stringToReplace);
-      let embedCode = buildEmbedCodeString(videoId, pluginConfig);
-      content = content.replace(stringToReplace, embedCode);
-    });
+
     return content;
   });
 };


### PR DESCRIPTION
In production, outputPath was null for XML files (at least on netlify). I had run into this on my own transforms as well. 

I found the readability of checking for outputPath existing and not ending with .html hard to comprehend, so I tweaked the logical order a bit as well. 