### PR TITLE
Add support for Lite Youtube

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,7 +1,7 @@
 const patternPresent = require('./lib/spotPattern.js');
 const extractVideoId = require('./lib/extractMatches.js');
 const buildEmbedCodeString = require('./lib/buildEmbed.js');
-const pluginDefaults = require('./lib/pluginDefaults.js');
+const { pluginDefaults } = require('./lib/pluginDefaults.js');
 
 module.exports = function (eleventyConfig, options) {
   const pluginConfig = Object.assign(pluginDefaults, options);
@@ -11,9 +11,9 @@ module.exports = function (eleventyConfig, options) {
       if (!matches) {
         return content;
       }
-      matches.forEach(function (stringToReplace) {
+      matches.forEach(function (stringToReplace, index) {
         let videoId = extractVideoId(stringToReplace);
-        let embedCode = buildEmbedCodeString(videoId, pluginConfig);
+        let embedCode = buildEmbedCodeString(videoId, pluginConfig, index);
         content = content.replace(stringToReplace, embedCode);
       });
       return content;

--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -1,4 +1,39 @@
-module.exports = function(id, options) {
+module.exports = function(id, options, index) {
+  let output;
+  if ( !!options.lite ) {
+    output = liteEmbed(id, options, index);
+  } else {
+    output = defaultEmbed(id, options);
+  }
+  return output;
+}
+
+function liteEmbed(id, options, index) {
+  let liteOpt = liteConfig(options);
+  let out = '';
+  // only include css and js once per html file
+  if ( index === 0 ) {
+    out += `<link rel="stylesheet" href="${liteOpt.css.path}">`;
+    out += `<script defer="defer" src="${liteOpt.js.path}"></script>`;
+  }
+  out += `<div id="${id}" class="${options.embedClass}">`;
+  out += `<lite-youtube videoid="${id}" style="background-image: url('https://i.ytimg.com/vi/${id}/hqdefault.jpg');">`;
+  out += `<div class="lty-playbtn"></div>`;
+  out += `</lite-youtube>`;
+  out += `</div>`;
+  return out;
+}
+
+function liteConfig(options){
+  const { liteDefaults } = require('./pluginDefaults.js');
+  if ( options.lite && typeof options.lite === 'boolean') {
+    return liteDefaults;
+  } else {
+    return Object.assign({}, liteDefaults, options.lite);
+  }
+}
+
+function defaultEmbed(id, options){
   // Build the string, using config data as we go
   // unique ID based on youtube video id
   let out =

--- a/lib/pluginDefaults.js
+++ b/lib/pluginDefaults.js
@@ -1,7 +1,17 @@
-module.exports = {
-  noCookie: true,
-  embedClass: 'eleventy-plugin-youtube-embed',
+exports.pluginDefaults = {
   allowAttrs: 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
+  allowAutoplay: false,
   allowFullscreen: true,
-  allowAutoplay: false
+  embedClass: 'eleventy-plugin-youtube-embed',
+  lite: false,
+  noCookie: true
 };
+
+exports.liteDefaults = {
+  css: {
+    path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css'
+  },
+  js: {
+    path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js'
+  }
+}

--- a/test.js
+++ b/test.js
@@ -68,6 +68,30 @@ validStrings.forEach(function(obj){
 
 // Test output of lite version of embed code
 const pluginLiteModeOptions = Object.assign({}, pluginDefaults, { lite: true });
+const pluginLiteModeOptionsAltCss = Object.assign({}, pluginDefaults, { 
+  lite: { 
+    css: { 
+      path: "https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.css"
+    }
+  } 
+});
+const pluginLiteModeOptionsAltJs = Object.assign({}, pluginDefaults, { 
+  lite: { 
+    js: { 
+      path: "https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.js"
+    }
+  } 
+});
+const pluginLiteModeOptionsAltBoth = Object.assign({}, pluginDefaults, { 
+  lite: { 
+    css: { 
+      path: "https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.css"
+    },
+    js: { 
+      path: "https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.js"
+    }
+  } 
+});
 validStrings.forEach(function(obj){
   test(`${obj.type} ideal case, lite embed, zero-index`, t => {
     let idealCase = `<p>${obj.str}</p>`;
@@ -97,6 +121,98 @@ validStrings.forEach(function(obj){
     </p>`;
     t.is(buildEmbedCodeString(extractVideoId(withLinksAndWhitespace), pluginLiteModeOptions, 0),
       `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css"><script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} ideal case, lite embed with alt script path, zero-index`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(buildEmbedCodeString(extractVideoId(idealCase), pluginLiteModeOptionsAltJs, 0),
+      `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css"><script defer="defer" src="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with links, lite embed with alt script path, zero-index`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withLinks), pluginLiteModeOptionsAltJs, 0),
+      `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css"><script defer="defer" src="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with whitespace, lite embed with alt script path, zero-index`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withWhitespace), pluginLiteModeOptionsAltJs, 0),
+      `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css"><script defer="defer" src="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with links and whitespace, lite embed with alt script path, zero-index`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withLinksAndWhitespace), pluginLiteModeOptionsAltJs, 0),
+      `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css"><script defer="defer" src="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+
+  test(`${obj.type} ideal case, lite embed with alt style path, zero-index`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(buildEmbedCodeString(extractVideoId(idealCase), pluginLiteModeOptionsAltCss, 0),
+      `<link rel="stylesheet" href="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.css"><script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with links, lite embed with alt style path, zero-index`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withLinks), pluginLiteModeOptionsAltCss, 0),
+      `<link rel="stylesheet" href="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.css"><script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with whitespace, lite embed with alt style path, zero-index`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withWhitespace), pluginLiteModeOptionsAltCss, 0),
+      `<link rel="stylesheet" href="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.css"><script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with links and whitespace, lite embed with alt style path, zero-index`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withLinksAndWhitespace), pluginLiteModeOptionsAltCss, 0),
+      `<link rel="stylesheet" href="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.css"><script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+
+  test(`${obj.type} ideal case, lite embed with alt style AND script path, zero-index`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(buildEmbedCodeString(extractVideoId(idealCase), pluginLiteModeOptionsAltBoth, 0),
+      `<link rel="stylesheet" href="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.css"><script defer="defer" src="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with links, lite embed with alt style AND script path, zero-index`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withLinks), pluginLiteModeOptionsAltBoth, 0),
+      `<link rel="stylesheet" href="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.css"><script defer="defer" src="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with whitespace, lite embed with alt style AND script path, zero-index`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withWhitespace), pluginLiteModeOptionsAltBoth, 0),
+      `<link rel="stylesheet" href="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.css"><script defer="defer" src="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with links and whitespace, lite embed with alt style AND script path, zero-index`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withLinksAndWhitespace), pluginLiteModeOptionsAltBoth, 0),
+      `<link rel="stylesheet" href="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.css"><script defer="defer" src="https://unpkg.com/lite-youtube-embed@0.0.0/src/lite-yt-embed.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
     );
   });
   test(`${obj.type} ideal case, lite embed, one-index`, t => {

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ const test = require('ava');
 const patternPresent = require('./lib/spotPattern.js');
 const extractVideoId = require('./lib/extractMatches.js');
 const buildEmbedCodeString = require('./lib/buildEmbed.js');
-const pluginDefaults = require('./lib/pluginDefaults.js');
+const { pluginDefaults } = require('./lib/pluginDefaults.js');
 
 const validStrings = [
   {type: 'Standard', str: 'https://www.youtube.com/watch?v=hIs5StN8J-0'},
@@ -23,7 +23,6 @@ const invalidStrings = [
   {type: 'With appended text', str: 'https://www.youtube.com/watch?v=hIs5StN8J-0 bar'},
   {type: 'With appended text, with link', str: '<a href="">https://www.youtube.com/watch?v=hIs5StN8J-0</a> bar'},
   {type: 'Playlist URL', str: 'https://www.youtube.com/playlist?list=PLv0jwu7G_DFVP0SGNlBiBtFVkV5LZ7SOU'},
-
 ]
 
 validStrings.forEach(function(obj){
@@ -63,6 +62,71 @@ validStrings.forEach(function(obj){
     t.is(extractVideoId(withLinksAndWhitespace), 'hIs5StN8J-0');
     t.is(buildEmbedCodeString(extractVideoId(withLinksAndWhitespace), pluginDefaults),
       '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+    );
+  });
+});
+
+// Test output of lite version of embed code
+const pluginLiteModeOptions = Object.assign({}, pluginDefaults, { lite: true });
+validStrings.forEach(function(obj){
+  test(`${obj.type} ideal case, lite embed, zero-index`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(buildEmbedCodeString(extractVideoId(idealCase), pluginLiteModeOptions, 0),
+      `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css"><script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with links, lite embed, zero-index`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withLinks), pluginLiteModeOptions, 0),
+      `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css"><script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with whitespace, lite embed, zero-index`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withWhitespace), pluginLiteModeOptions, 0),
+      `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css"><script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with links and whitespace, lite embed, zero-index`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withLinksAndWhitespace), pluginLiteModeOptions, 0),
+      `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css"><script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script><div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} ideal case, lite embed, one-index`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(buildEmbedCodeString(extractVideoId(idealCase), pluginLiteModeOptions, 1),
+      `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with links, lite embed, one-index`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withLinks), pluginLiteModeOptions, 1),
+      `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with whitespace, lite embed, one-index`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withWhitespace), pluginLiteModeOptions, 1),
+      `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+    );
+  });
+  test(`${obj.type} with links and whitespace, lite embed, one-index`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(buildEmbedCodeString(extractVideoId(withLinksAndWhitespace), pluginLiteModeOptions, 1),
+      `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
     );
   });
 });


### PR DESCRIPTION
Fix #26
Fix #4 

This PR adds support for The Paul Irish Lite YouTube Embed™.

Usage:

```js
eleventyConfig.addPlugin(embedYouTube, {
  lite: true
});
```
By default, it loads the JS and CSS files [from jsdelivr](https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/). You can substitute your own file URLs by passing an object instead of a boolean:

```js
eleventyConfig.addPlugin(embedYouTube, {
  lite: { 
    css: { 
      path: "some_other_url"
    },
    js: { 
      path: "some_other_url"
    }
  }
});
```

It includes the files only for the first embed on the page, but right now it makes no attempt to load the stylesheet in the `<head>` or the script lower in the `<body>`. I could see handling this with a script in the future but I worry about getting too cute by half.

[Ancient stack overflow threads](https://stackoverflow.com/questions/1642212/whats-the-difference-if-i-put-css-file-inside-head-or-body) say no CSS `<link>` elements in the body, but [the spec says stylesheets are literally `body-ok`](https://html.spec.whatwg.org/multipage/links.html#body-ok), so I'm inclined to go with it for now.
