### PR TITLE
Add npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,19 @@
+# Ignore gitignore (meta!)
+.gitignore
+
+# Ignore tests
+test.js
+test/
+
+# Ignore CI config
+.travis.yml
+
+# Ignore coverage files is redundant with gitignore, but just in case
+.nyc_output
+coverage/
+
+# Ignore editor style stuff
+.editorconfig
+
+# Ignore code of conduct
+CODE_OF_CONDUCT.md


### PR DESCRIPTION
Given the growing test footprint, I thought it was time to dial back the package size. Ignoring some junk brings the unpacked package to 12.4kB, 45% smaller than today's 22.8kB.