### PR TITLE
Add iframe lazyloading option

### DIFF
--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -58,6 +58,8 @@ function defaultEmbed(id, options){
   out += 'allow="' + options.allowAttrs + '"';
   // configurable fullscreen capability
   out += options.allowFullscreen ? ' allowfullscreen' : '';
+  //configurable iframe lazy-loading
+  out += options.lazy ? ' loading="lazy"' : '';
   out += '></iframe></div>';
   return out;
 }

--- a/lib/pluginDefaults.js
+++ b/lib/pluginDefaults.js
@@ -3,6 +3,7 @@ exports.pluginDefaults = {
   allowAutoplay: false,
   allowFullscreen: true,
   embedClass: 'eleventy-plugin-youtube-embed',
+  lazy: false,
   lite: false,
   noCookie: true
 };
@@ -14,4 +15,4 @@ exports.liteDefaults = {
   js: {
     path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js'
   }
-}
+};


### PR DESCRIPTION
This PR adds the option to use a `loading="lazy"` attribute on the standard YouTube iframe.