### PR TITLE
Add iframe title for accessibility

### DIFF
--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -45,7 +45,7 @@ function defaultEmbed(id, options){
   out += 'style="position:relative;width:100%;padding-top: 56.25%;">';
   out +=
     '<iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" ';
-  out += 'width="100%" height="100%" frameborder="0" ';
+  out += 'width="100%" height="100%" frameborder="0" title="Embedded YouTube video" ';
   out += 'src="https://www.';
   // default to nocookie domain
   out += options.noCookie ? "youtube-nocookie" : "youtube";

--- a/test.js
+++ b/test.js
@@ -31,7 +31,7 @@ validStrings.forEach(function(obj){
     t.truthy(patternPresent(idealCase));
     t.is(extractVideoId(idealCase), 'hIs5StN8J-0', 'foo');
     t.is(buildEmbedCodeString(extractVideoId(idealCase), pluginDefaults),
-      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
     );
   });
   test(`${obj.type} with links`, t => {
@@ -39,7 +39,7 @@ validStrings.forEach(function(obj){
     t.truthy(patternPresent(withLinks));
     t.is(extractVideoId(withLinks), 'hIs5StN8J-0');
     t.is(buildEmbedCodeString(extractVideoId(withLinks), pluginDefaults),
-      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
     );
   });
   test(`${obj.type} with whitespace`, t => {
@@ -49,7 +49,7 @@ validStrings.forEach(function(obj){
     t.truthy(patternPresent(withWhitespace));
     t.is(extractVideoId(withWhitespace), 'hIs5StN8J-0');
     t.is(buildEmbedCodeString(extractVideoId(withWhitespace), pluginDefaults),
-      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
     );
   });
   test(`${obj.type} with links and whitespace`, t => {
@@ -61,7 +61,7 @@ validStrings.forEach(function(obj){
     t.truthy(patternPresent(withLinksAndWhitespace));
     t.is(extractVideoId(withLinksAndWhitespace), 'hIs5StN8J-0');
     t.is(buildEmbedCodeString(extractVideoId(withLinksAndWhitespace), pluginDefaults),
-      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
     );
   });
 });


### PR DESCRIPTION
Close #38 

This PR adds a generic title to all YouTube embeds when using the default plugin behavior.

Currently I'm making the title a generic string ("Embedded YouTube video") because customizing the title of the iframe would require fetching data from YouTube about its contents, which would require a network request on each transform. I'd rather prevent that, at least in the default plugin behavior. Custom titles could be supported as a non-default feature down the road, I think.