### PR TITLE
Safer minified html and whitespace handling

### DIFF
--- a/lib/extractMatches.js
+++ b/lib/extractMatches.js
@@ -1,7 +1,13 @@
-const thisPattern = /<p>(?:\s*)(?:<a(?:.*)>)?(?:\s*)(?:https?:\/\/)?(?:w{3}\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/)?([A-Za-z0-9-_]{11})(?:\S*)(?:\s*)(?:<\/a>)?(?:\s*)<\/p>/;
+/**
+ * Video ID is 4th item in array of matches.
+ * [0]    = full matched string
+ * [1, 2] = zero-backtrack arbitrary whitespace, requires capture for lookahead
+ * [3]    = video ID
+ * [4, 5] = zero-backtrack arbitrary whitespace, requires capture for lookahead
+ */
+
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??(?:w{3}\.)??(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/)??([A-Za-z0-9-_]{11})(?:[^\s<>]*)(?=(\s*))\4(?:<\/a>)??(?=(\s*))\5<\/p>/;
 
 module.exports = function(str) {
-  // CHANGE @1.3.0: Remove named capture group (Node ^10). Instead use destructuring (Node ^6).
-  let [ match, out ] = thisPattern.exec(str);
-  return out;
+  return str.match(pattern)[3]
 }

--- a/lib/spotPattern.js
+++ b/lib/spotPattern.js
@@ -1,4 +1,4 @@
-const pattern = /<p>(\s*)(<a(.*)>)?(\s*)(https?:\/\/)?(w{3}\.)?(youtube\.com|youtu\.be)\/(watch\?v=|embed\/)?([A-Za-z0-9-_]{11})(\S*)(\s*)(<\/a>)?(\s*)<\/p>/g;
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??(?:w{3}\.)??(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/)??([A-Za-z0-9-_]{11})(?:[^\s<>]*)(?=(\s*))\4(?:<\/a>)??(?=(\s*))\5<\/p>/g;
 
 module.exports = function(str) {
   return str.match(pattern);

--- a/test.js
+++ b/test.js
@@ -73,6 +73,18 @@ validStrings.forEach(function(obj){
   });
 });
 
+/**
+ * Test that regex isn't greedily consuming subsequent paragraphs in minified HTML
+ */
+ validStrings.forEach(function(obj){
+  test(`${obj.type} minified HTML with multiple paragraph tags on a single line`, t => {
+    let paragraph = "<p>https://www.youtube.com/watch?v=hIs5StN8J-0</p><p>Foo</p>";
+    let paragraphWithLinks = '<p><a href="foo">https://www.youtube.com/watch?v=hIs5StN8J-0</a></p><p>Foo</p>';
+    t.deepEqual(patternPresent(paragraph), ['<p>https://www.youtube.com/watch?v=hIs5StN8J-0</p>']);
+    t.deepEqual(patternPresent(paragraphWithLinks), ['<p><a href="foo">https://www.youtube.com/watch?v=hIs5StN8J-0</a></p>']);
+  });
+});
+
 // Test output of lite version of embed code
 const pluginLiteModeOptions = Object.assign({}, pluginDefaults, { lite: true });
 const pluginLiteModeOptionsAltCss = Object.assign({}, pluginDefaults, { 


### PR DESCRIPTION
This PR refactors two regular expressions to improve performance of arbitrary whitespace handling, as well as preventing a case where the plugin can overwrite subsequent paragraphs if the HTML has been minified.

Details:
- RegEx group to accommodate any arbitrary characters following the video ID is now more precise, to prevent consuming subsequent `<p>` tags. Changed from `(?:\S*)` to `(?:[^\s<>]*)` to negatively match whitespace and angle brackets instead of any non-whitespace character.
- Handles arbitrary whitespace more safely, using the positive lookaheads trick to [mimic atomic groups](https://blog.stevenlevithan.com/archives/mimic-atomic-groups), preventing potentially [catastrophic backtracking](https://snyk.io/blog/redos-and-catastrophic-backtracking/).
- It also adds tests to verify the behavior.