### PR TITLE
Fix error in output

### DIFF
--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -53,7 +53,7 @@ function defaultEmbed(id, options){
   let out =
     '<div id="' + id + '" ';
   // global class name for all embeds, use this for styling
-  out += 'class="' + options.embedClass + '"';
+  out += 'class="' + options.embedClass + '" ';
   // intrinsic aspect ratio; currently hard-coded to 16:9
   // TODO: make configurable somehow
   out += 'style="position:relative;width:100%;padding-top: 56.25%;">';

--- a/test.js
+++ b/test.js
@@ -38,7 +38,7 @@ validStrings.forEach(function(obj){
     t.truthy(patternPresent(idealCase));
     t.is(extractVideoId(idealCase), 'hIs5StN8J-0', 'foo');
     t.is(buildEmbedCodeString(extractVideoId(idealCase), pluginDefaults),
-      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
     );
   });
   test(`${obj.type} with links`, t => {
@@ -46,7 +46,7 @@ validStrings.forEach(function(obj){
     t.truthy(patternPresent(withLinks));
     t.is(extractVideoId(withLinks), 'hIs5StN8J-0');
     t.is(buildEmbedCodeString(extractVideoId(withLinks), pluginDefaults),
-      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
     );
   });
   test(`${obj.type} with whitespace`, t => {
@@ -56,7 +56,7 @@ validStrings.forEach(function(obj){
     t.truthy(patternPresent(withWhitespace));
     t.is(extractVideoId(withWhitespace), 'hIs5StN8J-0');
     t.is(buildEmbedCodeString(extractVideoId(withWhitespace), pluginDefaults),
-      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
     );
   });
   test(`${obj.type} with links and whitespace`, t => {
@@ -68,7 +68,7 @@ validStrings.forEach(function(obj){
     t.truthy(patternPresent(withLinksAndWhitespace));
     t.is(extractVideoId(withLinksAndWhitespace), 'hIs5StN8J-0');
     t.is(buildEmbedCodeString(extractVideoId(withLinksAndWhitespace), pluginDefaults),
-      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+      '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
     );
   });
 });


### PR DESCRIPTION
Without a space here, it creates invalid HTML, because there is no space between the HTML attributes.

Before:

```html
<div id="some-id" class="youtube-video"style="position:relative;width:100%;padding-top: 56.25%;">
```

Errors showing in Firefox's view source:

<img width="784" alt="HTML error" src="https://user-images.githubusercontent.com/96479/153314823-95b6a15b-f7b7-4c55-934c-805e65ff087f.png">

After:

```html
<div id="some-id" class="youtube-video" style="position:relative;width:100%;padding-top: 56.25%;">
```