### PR TITLE
Add actions to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,10 @@ updates:
   - dependency-name: ava
     versions:
     - "> 3.12.1, < 4"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: friday
+    time: "10:00"
+    timezone: EST


### PR DESCRIPTION
This PR adds new settings to Dependabot’s config file to support [keeping GitHub Actions up to date automatically](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).