### PR TITLE
Remove testing for unsupported Node versions

### DIFF
--- a/.github/workflows/test-and-codecov.yml
+++ b/.github/workflows/test-and-codecov.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        node: ["8", "10", "12", "14", "16", "17"]
+        node: ["12", "14", "16", "18", "19"]
     name: Node.js ${{ matrix.node }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
See https://github.com/gfscott/eleventy-plugin-embed-everything/discussions/103

In addition, this PR bumps the versions of the Actions being used in CI.